### PR TITLE
Prepare Shell App to use Shared module

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,4 @@ $RECYCLE.BIN/
 .DS_Store
 Thumbs.db
 UserInterfaceState.xcuserstate
+/crPlayer.iml

--- a/config/watch.config.js
+++ b/config/watch.config.js
@@ -1,0 +1,20 @@
+var watch = require('../node_modules/@ionic/app-scripts/dist/watch');
+var copy = require('../node_modules/@ionic/app-scripts/dist/copy');
+var copyConfig = require('../node_modules/@ionic/app-scripts/config/copy.config');
+
+// this is a custom dictionary to make it easy to extend/override
+// provide a name for an entry, it can be anything such as 'srcFiles' or 'copyConfig'
+// then provide an object with the paths, options, and callback fields populated per the Chokidar docs
+// https://www.npmjs.com/package/chokidar
+
+module.exports = {
+  srcFiles: {
+    paths: [
+      '{{SRC}}/**/*.(ts|html|s(c|a)ss)',
+      '{{SRC}}/../../front-end-common/**/*.(ts|html|s(c|a)ss)'
+    ],
+    options: { ignored: ['{{SRC}}/**/*.spec.ts', '{{SRC}}/**/*.e2e.ts', '**/*.DS_Store', '{{SRC}}/index.html'] },
+    callback: watch.buildUpdate
+  },
+  copyConfig: copy.copyConfigToWatchConfig()
+};

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -1,0 +1,151 @@
+/*
+ * The webpack config exports an object that has a valid webpack configuration
+ * For each environment name. By default, there are two Ionic environments:
+ * "dev" and "prod". As such, the webpack.config.js exports a dictionary object
+ * with "keys" for "dev" and "prod", where the value is a valid webpack configuration
+ * For details on configuring webpack, see their documentation here
+ * https://webpack.js.org/configuration/
+ */
+
+var path = require('path');
+var webpack = require('webpack');
+var ionicWebpackFactory = require(process.env.IONIC_WEBPACK_FACTORY);
+
+var ModuleConcatPlugin = require('webpack/lib/optimize/ModuleConcatenationPlugin');
+var PurifyPlugin = require('@angular-devkit/build-optimizer').PurifyPlugin;
+const TsConfigPathsPlugin = require('awesome-typescript-loader').TsConfigPathsPlugin;
+
+var optimizedProdLoaders = [
+  {
+    test: /\.json$/,
+    loader: 'json-loader'
+  },
+  {
+    test: /\.js$/,
+    loader: [
+      {
+        loader: process.env.IONIC_CACHE_LOADER
+      },
+
+      {
+        loader: '@angular-devkit/build-optimizer/webpack-loader',
+        options: {
+          sourceMap: true
+        }
+      },
+    ]
+  },
+  {
+    test: /\.ts$/,
+    loader: [
+      {
+        loader: process.env.IONIC_CACHE_LOADER
+      },
+
+      {
+        loader: '@angular-devkit/build-optimizer/webpack-loader',
+        options: {
+          sourceMap: true
+        }
+      },
+
+      {
+        loader: process.env.IONIC_WEBPACK_LOADER
+      }
+    ]
+  }
+];
+
+function getProdLoaders() {
+  if (process.env.IONIC_OPTIMIZE_JS === 'true') {
+    return optimizedProdLoaders;
+  }
+  return devConfig.module.loaders;
+}
+
+var devConfig = {
+  entry: process.env.IONIC_APP_ENTRY_POINT,
+  output: {
+    path: '{{BUILD}}',
+    publicPath: 'build/',
+    filename: '[name].js',
+    devtoolModuleFilenameTemplate: ionicWebpackFactory.getSourceMapperFunction(),
+  },
+  devtool: process.env.IONIC_SOURCE_MAP_TYPE,
+
+  resolve: {
+    extensions: ['.ts', '.js', '.json'],
+    modules: [path.resolve('node_modules')],
+    plugins: [
+      new TsConfigPathsPlugin(/* {configFileName, compiler} */)
+    ]
+  },
+
+  module: {
+    loaders: [
+      {
+        test: /\.json$/,
+        loader: 'json-loader'
+      },
+      {
+        test: /\.ts$/,
+        loader: process.env.IONIC_WEBPACK_LOADER
+      }
+    ]
+  },
+
+  plugins: [
+    ionicWebpackFactory.getIonicEnvironmentPlugin(),
+    ionicWebpackFactory.getCommonChunksPlugin()
+  ],
+
+  // Some libraries import Node modules but don't use them in the browser.
+  // Tell Webpack to provide empty mocks for them so importing them works.
+  node: {
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty'
+  }
+};
+
+var prodConfig = {
+  entry: process.env.IONIC_APP_ENTRY_POINT,
+  output: {
+    path: '{{BUILD}}',
+    publicPath: 'build/',
+    filename: '[name].js',
+    devtoolModuleFilenameTemplate: ionicWebpackFactory.getSourceMapperFunction(),
+  },
+  devtool: process.env.IONIC_SOURCE_MAP_TYPE,
+
+  resolve: {
+    extensions: ['.ts', '.js', '.json'],
+    modules: [path.resolve('node_modules')]
+  },
+
+  module: {
+    loaders: getProdLoaders()
+  },
+
+  plugins: [
+    ionicWebpackFactory.getIonicEnvironmentPlugin(),
+    ionicWebpackFactory.getCommonChunksPlugin(),
+    new ModuleConcatPlugin(),
+    new PurifyPlugin()
+  ],
+
+  // Some libraries import Node modules but don't use them in the browser.
+  // Tell Webpack to provide empty mocks for them so importing them works.
+  node: {
+    fs: 'empty',
+    net: 'empty',
+    tls: 'empty'
+  }
+};
+
+
+module.exports = {
+  dev: devConfig,
+  prod: prodConfig
+};
+

--- a/package.json
+++ b/package.json
@@ -1,9 +1,13 @@
 {
-  "name": "crPlayer",
+  "name": "cr-player",
   "version": "0.0.1",
-  "author": "Ionic Framework",
-  "homepage": "http://ionicframework.com/",
+  "homepage": "https://clueride.com/",
+  "description": "Clue Ride Game App",
   "private": true,
+  "config": {
+    "ionic_webpack": "config/webpack.config.js",
+    "ionic_watch": "config/watch.config.js"
+  },
   "scripts": {
     "clean": "ionic-app-scripts clean",
     "build": "ionic-app-scripts build",
@@ -31,8 +35,9 @@
     "zone.js": "0.8.18"
   },
   "devDependencies": {
+    "@angular/cli": "^1.6.3",
     "@ionic/app-scripts": "3.1.0",
+    "awesome-typescript-loader": "file:node_modules/awesome-typescript-loader",
     "typescript": "2.4.2"
-  },
-  "description": "An Ionic project"
+  }
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -2,6 +2,7 @@ import { Component, ViewChild } from '@angular/core';
 import { Nav, Platform } from 'ionic-angular';
 import { StatusBar } from '@ionic-native/status-bar';
 import { SplashScreen } from '@ionic-native/splash-screen';
+import { TokenService, RegistrationPage } from 'front-end-common';
 
 import { HomePage } from '../pages/home/home';
 import { ListPage } from '../pages/list/list';
@@ -12,11 +13,16 @@ import { ListPage } from '../pages/list/list';
 export class MyApp {
   @ViewChild(Nav) nav: Nav;
 
-  rootPage: any = HomePage;
+  rootPage: any;
 
   pages: Array<{title: string, component: any}>;
 
-  constructor(public platform: Platform, public statusBar: StatusBar, public splashScreen: SplashScreen) {
+  constructor(
+    public platform: Platform,
+    public statusBar: StatusBar,
+    public splashScreen: SplashScreen,
+    public tokenService: TokenService,
+  ) {
     this.initializeApp();
 
     // used for an example of ngFor and navigation
@@ -41,4 +47,17 @@ export class MyApp {
     // we wouldn't want the back button to show in this scenario
     this.nav.setRoot(page.component);
   }
+
+  ngOnInit() {
+    console.log("App is initialized");
+    /* This is dependent on the loadToken having been run (promise resolved) as the initialization of the app. */
+    if (this.tokenService.isGuest()) {
+      console.log("1. App is Unregistered");
+      this.rootPage = RegistrationPage;
+    } else {
+      console.log("1. App is Registered as " + this.tokenService.getPrincipalName());
+      this.rootPage = HomePage;
+    }
+  }
+
 }

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { BrowserModule } from '@angular/platform-browser';
+import { ComponentsModule } from 'front-end-common';
 import { ErrorHandler, NgModule } from '@angular/core';
 import { IonicApp, IonicErrorHandler, IonicModule } from 'ionic-angular';
 
@@ -18,6 +19,7 @@ import { SplashScreen } from '@ionic-native/splash-screen';
   imports: [
     BrowserModule,
     IonicModule.forRoot(MyApp),
+    ComponentsModule.forRoot(),
   ],
   bootstrap: [IonicApp],
   entryComponents: [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -10,6 +10,10 @@
     ],
     "module": "es2015",
     "moduleResolution": "node",
+    "baseUrl": "./",
+    "paths": {
+      "front-end-common": ["../front-end-common/index"]
+    },
     "sourceMap": true,
     "target": "es5"
   },


### PR DESCRIPTION
* Sets up over-ridden webpack.config and watch.config to handle dev cycle
against code in the shared module.
* Adjusts the app component to use the new shared module.
* Adjusts package.json to bring in the new plugin and the config files.