### PR TITLE
Support for implementing Registration UC

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -76,18 +76,19 @@
         <splash height="480" src="resources/ios/splash/Default~iphone.png" width="320" />
         <splash height="2732" src="resources/ios/splash/Default@2x~universal~anyany.png" width="2732" />
     </platform>
-    <plugin name="ionic-plugin-keyboard" spec="~2.2.1" />
-    <plugin name="cordova-plugin-whitelist" spec="1.3.1" />
-    <plugin name="cordova-plugin-device" spec="1.1.4" />
-    <plugin name="cordova-plugin-splashscreen" spec="~4.0.1" />
-    <plugin name="cordova-plugin-ionic-webview" spec="^1.1.11" />
-    <engine name="android" spec="~6.2.3" />
-    <plugin name="cordova-plugin-safariviewcontroller" spec="^1.5.2" />
-    <engine name="browser" spec="~4.1.0" />
+    <allow-navigation href="http://10.0.0.6:8100" />
+    <engine name="android" spec="^6.2.3" />
+    <engine name="browser" spec="^4.1.0" />
     <plugin name="cordova-plugin-customurlscheme" spec="^4.3.0">
         <variable name="URL_SCHEME" value="com.clueride" />
         <variable name="ANDROID_SCHEME" value="com.clueride" />
         <variable name="ANDROID_HOST" value="clueride.auth0.com" />
         <variable name="ANDROID_PATHPREFIX" value="/cordova/com.clueride/callback" />
     </plugin>
+    <plugin name="cordova-plugin-device" spec="^1.1.4" />
+    <plugin name="cordova-plugin-ionic-webview" spec="^1.1.16" />
+    <plugin name="cordova-plugin-safariviewcontroller" spec="^1.5.2" />
+    <plugin name="cordova-plugin-splashscreen" spec="^4.0.3" />
+    <plugin name="cordova-plugin-whitelist" spec="^1.3.1" />
+    <plugin name="ionic-plugin-keyboard" spec="^2.2.1" />
 </widget>

--- a/package.json
+++ b/package.json
@@ -16,15 +16,15 @@
         "ionic:serve": "ionic-app-scripts serve"
     },
     "dependencies": {
-        "@angular/common": "5.0.0",
-        "@angular/compiler": "5.0.0",
-        "@angular/compiler-cli": "5.0.0",
-        "@angular/core": "5.0.0",
-        "@angular/forms": "5.0.0",
-        "@angular/http": "5.0.0",
-        "@angular/platform-browser": "5.0.0",
-        "@angular/platform-browser-dynamic": "5.0.0",
-        "@angular/router": "5.0.0",
+        "@angular/common": "4.1.0",
+        "@angular/compiler": "4.1.0",
+        "@angular/compiler-cli": "4.1.0",
+        "@angular/core": "4.1.0",
+        "@angular/forms": "4.1.0",
+        "@angular/http": "4.1.0",
+        "@angular/platform-browser": "4.1.0",
+        "@angular/platform-browser-dynamic": "4.1.0",
+        "@angular/router": "4.1.0",
         "@auth0/cordova": "^0.3.0",
         "@ionic-native/core": "4.3.2",
         "@ionic-native/splash-screen": "4.3.2",
@@ -45,6 +45,7 @@
         "ionicons": "3.0.0",
         "rxjs": "5.5.2",
         "sw-toolbox": "3.6.0",
+        "ws": "^3.3.2",
         "zone.js": "0.8.18"
     },
     "devDependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -31,7 +31,7 @@ export class MyApp {
     // used for an example of ngFor and navigation
     this.pages = [
       { title: 'Home', component: HomePage },
-      { title: 'List', component: ListPage }
+      { title: 'List', component: ListPage },
     ];
 
   }
@@ -59,12 +59,12 @@ export class MyApp {
   ngOnInit() {
     console.log("App is initialized");
     /* This is dependent on the loadToken having been run (promise resolved) as the initialization of the app. */
+    this.nav.setRoot(HomePage);
     if (this.authService.isAuthenticated()) {
       console.log("1. App is Registered under " + this.profileService.getPrincipal());
-      this.rootPage = HomePage;
     } else {
       console.log("1. App is Unregistered");
-      this.rootPage = RegistrationPage;
+      this.nav.push(RegistrationPage);
     }
   }
 

--- a/src/index.html
+++ b/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en" dir="ltr">
 <head>
   <meta charset="UTF-8">
-  <title>Ionic App</title>
+  <title>Player App</title>
   <meta name="viewport" content="viewport-fit=cover, width=device-width, initial-scale=1.0, minimum-scale=1.0, maximum-scale=1.0, user-scalable=no">
   <meta name="format-detection" content="telephone=no">
   <meta name="msapplication-tap-highlight" content="no">
@@ -10,7 +10,7 @@
   <link rel="icon" type="image/x-icon" href="assets/icon/favicon.ico">
   <link rel="manifest" href="manifest.json">
   <meta name="theme-color" content="#4e8ef7">
-  
+
   <!-- add to homescreen for ios -->
   <meta name="apple-mobile-web-app-capable" content="yes">
   <meta name="apple-mobile-web-app-status-bar-style" content="black">


### PR DESCRIPTION
THe significant functional change was to allow the Registration page
to be pushed from the Home page.  This allowed the Registration process
to complete without having to know where it was being pushed from -- pop
up when the process was complete.

Also contains back-versioning of Angular from 5.0 back to 4.1 until the
Page Title thing gets resolved.  (This broke all my BDD tests that
depended on seeing the title of a page -- which was all of them.)