### PR TITLE
PLAY-6 Separate ID to avoid collision with other clueride.com apps

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -1,5 +1,5 @@
 <?xml version='1.0' encoding='utf-8'?>
-<widget id="com.clueride" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
+<widget id="com.clueride.player" version="0.0.1" xmlns="http://www.w3.org/ns/widgets" xmlns:cdv="http://cordova.apache.org/ns/1.0">
     <name>Clue Ride Player</name>
     <description>Player module for Clue Ride Ionic Mobile App</description>
     <author href="https://clueride.com/">Clue Ride</author>


### PR DESCRIPTION
Simple change to the "widget" ID in the config.xml.