### PR TITLE
PLAY-27 Page transitions follow SSEs: Attraction/Rolling to Puzzle up…

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -18,6 +18,7 @@ import {TeamPageModule} from "../pages/team/team.module";
 import {RollingPage} from "../pages/rolling/rolling";
 import {RollingPageModule} from "../pages/rolling/rolling.module";
 import {ServerEventsProvider} from "../providers/server-events/server-events";
+import { GameStateProvider } from '../providers/game-state/game-state';
 
 @NgModule({
   declarations: [
@@ -47,7 +48,8 @@ import {ServerEventsProvider} from "../providers/server-events/server-events";
     StatusBar,
     SplashScreen,
     {provide: ErrorHandler, useClass: IonicErrorHandler},
-    ServerEventsProvider
+    ServerEventsProvider,
+    GameStateProvider
   ]
 })
 export class AppModule {}

--- a/src/pages/puzzle/puzzle.ts
+++ b/src/pages/puzzle/puzzle.ts
@@ -15,7 +15,11 @@ import { IonicPage, NavController, NavParams } from 'ionic-angular';
 })
 export class PuzzlePage {
 
-  constructor(public navCtrl: NavController, public navParams: NavParams) {
+  constructor(
+    public navCtrl: NavController,
+    public navParams: NavParams
+  ) {
+
   }
 
   ionViewDidLoad() {

--- a/src/pages/rolling/rolling.ts
+++ b/src/pages/rolling/rolling.ts
@@ -33,10 +33,13 @@ export class RollingPage {
   }
 
   ionViewDidLoad() {
-    const outingId = 3;
     console.log('ionViewDidLoad RollingPage');
 
+    // TODO: CA-376 how to establish Outing?
+    const outingId = 3;
+
     this.serverEvents.initializeSubscriptions(outingId);
+
     this.outingService.get(
       outingId
     ).subscribe(

--- a/src/providers/game-state/game-state.ts
+++ b/src/providers/game-state/game-state.ts
@@ -1,0 +1,45 @@
+import {Injectable} from "@angular/core";
+import {App} from "ionic-angular";
+
+/*
+  Generated class for the GameStateProvider provider.
+
+  See https://angular.io/guide/dependency-injection for more info on providers
+  and Angular DI.
+*/
+@Injectable()
+export class GameStateProvider {
+
+  constructor(
+    public app: App   // TODO: Temporary solution just to see if pages can be changed based on events
+  ) {
+    console.log('Hello GameStateProvider Provider');
+  }
+
+  updateFromEvent(eventJson: string) {
+    let event = JSON.parse(eventJson);
+
+    switch (event.event) {
+      case "Team Assembled":
+      case "Arrival":
+        /* Case where we send out a Puzzle to be solved. */
+        this.app.getRootNav().push("PuzzlePage");   // TODO: getRootNav is deprecated
+        break;
+
+      case "Departure":
+        /* Case where we update the map to show the next path and we begin riding again. */
+        this.app.getRootNav().pop()
+          .then(
+            (value => {
+              this.app.getRootNav().push("RollingPage");
+            })
+          );
+        break;
+
+      default:
+        console.log("Unrecognized Event: " + event.event);
+        break;
+    }
+  }
+
+}

--- a/src/providers/server-events/server-events.ts
+++ b/src/providers/server-events/server-events.ts
@@ -1,6 +1,7 @@
 import { Injectable } from '@angular/core';
 import {EventSourcePolyfill} from "ng-event-source";
 import {TokenService} from "../../../../front-end-common/index";
+import {GameStateProvider} from "../game-state/game-state";
 
 const gameStateUrl: string = 'http://sse.clueride.com/game-state-broadcast';
 
@@ -13,7 +14,8 @@ export class ServerEventsProvider {
   private eventSource: EventSourcePolyfill;
 
   constructor(
-    private tokenService: TokenService
+    private tokenService: TokenService,
+    private gameStateService: GameStateProvider
   ) {
   }
 
@@ -35,6 +37,7 @@ export class ServerEventsProvider {
       this.eventSource.onmessage = (
         (messageEvent) => {
           console.log("SSE Message: " + messageEvent.data)
+          this.gameStateService.updateFromEvent(messageEvent.data);
         }
       );
 


### PR DESCRIPTION
…on arrival, Puzzle to Rollin...

- Adds Skeleton Game State Provider (service) for handling the events from SSE.

This is sufficient to watch the pages change in the proper order, but no
data is shown that would indicate we're at the correct step.

Currently uses the NavController from the App; may want to consider alternatives.