### PR TITLE
PLAY-32 Rolling page pushes during state transitions are piling up

### DIFF
--- a/src/components/begin-game/begin-game.ts
+++ b/src/components/begin-game/begin-game.ts
@@ -20,7 +20,7 @@ export class BeginGameComponent {
 
   public beginGame() {
     console.log('Beginning Game');
-    this.navCtrl.push("RollingPage");
+    this.navCtrl.setRoot("RollingPage");
   }
 
 }

--- a/src/providers/game-state/game-state.ts
+++ b/src/providers/game-state/game-state.ts
@@ -1,5 +1,5 @@
 import {Injectable} from "@angular/core";
-import {App} from "ionic-angular";
+import {App, NavController} from "ionic-angular";
 
 /*
   Generated class for the GameStateProvider provider.
@@ -23,17 +23,13 @@ export class GameStateProvider {
       case "Team Assembled":
       case "Arrival":
         /* Case where we send out a Puzzle to be solved. */
-        this.app.getRootNav().push("PuzzlePage");   // TODO: getRootNav is deprecated
+        (<NavController>this.app.getRootNavById('n4')).push("PuzzlePage");
         break;
 
       case "Departure":
         /* Case where we update the map to show the next path and we begin riding again. */
-        this.app.getRootNav().pop()
-          .then(
-            (value => {
-              this.app.getRootNav().push("RollingPage");
-            })
-          );
+        (<NavController>this.app.getRootNavById('n4')).popToRoot();
+        // Do I need to respond to the promise?
         break;
 
       default:


### PR DESCRIPTION
- Changes the Root to "Rolling" page once we begin play.
- Changes the Rolling response to pop back out to Rolling page.

Also gets rid of the deprecated getRootNav() for Ionic 3 which is probably
being replaced by the Angular style of Routing in Ionic 4.

More details: https://forum.ionicframework.com/t/getrootnav-deprecated-use-getrootnavbyid-whats-the-value-of-the-root-nav-id/96271