### PR TITLE
PLAY-43 Separate out the routing logic for determining which page to …

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
         "ngx-restangular": "^2.0.2",
         "rxjs": "5.5.2",
         "sw-toolbox": "3.6.0",
-        "ws": "^3.3.2",
         "zone.js": "0.8.18"
     },
     "devDependencies": {

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -1,5 +1,7 @@
+import {AppState} from "../providers/app-state/app-state";
+import {AppStateService} from "../providers/app-state/app-state.service";
 import Auth0Cordova from "@auth0/cordova";
-import {AuthService, RegistrationPage} from "front-end-common";
+import {AuthService} from "front-end-common";
 import {Component, ViewChild} from "@angular/core";
 import {Nav, Platform} from "ionic-angular";
 import {Observable} from "rxjs/Observable";
@@ -7,16 +9,16 @@ import {SplashScreen} from "@ionic-native/splash-screen";
 import {StatusBar} from "@ionic-native/status-bar";
 import {Subject} from "rxjs/Subject";
 
-import {HomePage} from "../pages/home/home";
-import {InvitePage} from "../pages/invite/invite";
-import {OutingPage} from "../pages/outing/outing";
-import {TeamPage} from "../pages/team/team";
 import {BadgesPage} from "../pages/badges/badges";
+import {HomePage} from "../pages/home/home";
+import {OutingPage} from "../pages/outing/outing";
 import {RollingPage} from "../pages/rolling/rolling";
+import {TeamPage} from "../pages/team/team";
 
 @Component({
   templateUrl: 'app.html'
 })
+
 export class MyApp {
   @ViewChild(Nav) nav: Nav;
 
@@ -29,6 +31,7 @@ export class MyApp {
     public statusBar: StatusBar,
     public splashScreen: SplashScreen,
     public authService: AuthService,
+    public appStateService: AppStateService,
   ) {
     this.initializeApp();
 
@@ -39,8 +42,6 @@ export class MyApp {
       { title: 'Badges', component: BadgesPage },
       { title: 'Team', component: TeamPage },
       { title: 'Play Game', component: RollingPage },
-      /* Temporary for ease of exercising the InviteService calls. */
-      { title: 'Invite Page', component: InvitePage },
     ];
 
   }
@@ -67,11 +68,12 @@ export class MyApp {
 
   ngOnInit() {
     console.log("App is initialized");
+    /* URL Scheme determines the URL where we respond to callbacks from Identity Provider. */
     this.authService.setUrlScheme("com.clueride.player");
+
     this.checkDeviceRegistered().subscribe(
       (result) => {
-        /* We're registered. */
-        console.log("Successfully registered.");
+        /* Nothing to be done; we're now on the correct initial page. */
       },
       () => {
         /* Problem. */
@@ -88,11 +90,10 @@ export class MyApp {
       (needsRegistration) => {
         let pageReadyPromise: Promise<void>;
 
-        pageReadyPromise = this.nav.setRoot(HomePage);
         if (needsRegistration) {
-          pageReadyPromise = this.nav.push(RegistrationPage);
+          pageReadyPromise = this.appStateService.prepareAndShowPage(AppState.UNREGISTERED);
         } else {
-          pageReadyPromise = this.nav.push(InvitePage);
+          pageReadyPromise = this.appStateService.checkInviteIsAccepted();
         }
 
         pageReadyPromise.then(

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -7,6 +7,7 @@ import {MyApp} from "./app.component";
 import {StatusBar} from "@ionic-native/status-bar";
 import {SplashScreen} from "@ionic-native/splash-screen";
 
+import {AppStateService} from '../providers/app-state/app-state.service';
 import {BadgesPage} from "../pages/badges/badges";
 import {BadgesPageModule} from "../pages/badges/badges.module";
 import {GameStateProvider} from "../providers/game-state/game-state";
@@ -49,11 +50,12 @@ import {TeamPageModule} from "../pages/team/team.module";
     TeamPage,
   ],
   providers: [
+    AppStateService,
+    GameStateProvider,
+    ServerEventsProvider,
     StatusBar,
     SplashScreen,
     {provide: ErrorHandler, useClass: IonicErrorHandler},
-    ServerEventsProvider,
-    GameStateProvider
   ]
 })
 

--- a/src/providers/app-state/app-state.service.ts
+++ b/src/providers/app-state/app-state.service.ts
@@ -1,0 +1,117 @@
+import {App, NavController} from "ionic-angular";
+import {AppState} from "./app-state";
+import {Injectable} from "@angular/core";
+import {RegistrationPage, InviteService, SessionInviteState} from "../../../../front-end-common/index";
+import {HomePage} from "../../pages/home/home";
+import {InvitePage} from "../../pages/invite/invite";
+import {ProfileService, ConfirmationListener, ConfirmationState} from "../../../../front-end-common/src/providers/profile/profile.service";
+
+/**
+ * Provides the logic for arranging Application State changes:
+ * - Needs Registration.
+ * - Ready to Play; we have an accepted invitation and outing.
+ * - Outstanding Invitation to be accepted.
+ * - No outing or invitation.
+ * Much of the logic is implemented on the server -- the InviteService
+ * uses the REST end-point that returns Invitation State for a given session.
+ */
+@Injectable()
+export class AppStateService implements ConfirmationListener {
+
+  private nav: NavController;
+
+  constructor(
+    public app: App,
+    public inviteService: InviteService,
+    public profileService: ProfileService,
+  ) {
+    /** Add ourselves to the list of profile listeners. */
+    profileService.listeners.push(this);
+  }
+
+  /**
+   * Listens for a confirmation event and when the right event occurs,
+   * evaluates which is the next page to present.
+   */
+  public canWeSwitch(confirmationState: ConfirmationState) {
+    if (confirmationState.authenticated && confirmationState.confirmed) {
+      this.checkInviteIsAccepted()
+        .then()
+        .catch();
+    }
+  }
+
+  /**
+   * Based on the inbound AppState, transition to the next state.
+   *
+   * NOTE: This is similar to the approach taken for GameState, but
+   * there may be existing routing and state code from Angular to
+   * handle this feature.
+   *
+   * @param appState
+   */
+  prepareAndShowPage(appState: AppState): Promise<void> {
+    let pageReadyPromise: Promise<void>;
+
+    this.nav = <NavController>this.app.getRootNavById('n4');
+
+    switch(appState) {
+      case AppState.UNREGISTERED:
+        pageReadyPromise = this.nav.setRoot(RegistrationPage);
+        break;
+
+      case AppState.READY_TO_PLAY:
+        pageReadyPromise = this.nav.setRoot(HomePage);
+        break;
+
+      case AppState.INVITED:
+        pageReadyPromise = this.nav.setRoot(InvitePage);
+        break;
+
+      case AppState.NO_INVITES:
+        // TODO: Temporary until we create the new page
+        pageReadyPromise = this.nav.setRoot(HomePage);
+        break;
+
+      default:
+      case AppState.EXCEPTION:
+        // TODO: Define an Exception page (maybe the server is down?)
+        console.log("Unrecognized state: " + appState);
+        break;
+    }
+
+    return pageReadyPromise;
+  }
+
+  /**
+   * Opens either the Home Page for an outing, the Invitation Page for
+   * an open invitation, or a new page yet to be figured out if user
+   * has no current invitations or outings.
+   */
+  public async checkInviteIsAccepted(): Promise<void> {
+    let pagePromise: Promise<void> = new Promise(
+      resolve => {}
+    );
+
+    await this.inviteService.inviteState().subscribe(
+      (inviteState) => {
+        switch (SessionInviteState[inviteState]) {
+          case SessionInviteState.ACCEPTED_INVITE:
+            pagePromise = this.prepareAndShowPage(AppState.READY_TO_PLAY);
+            break;
+          case SessionInviteState.OPEN_INVITE:
+          case SessionInviteState.DECLINED_INVITES:
+            pagePromise = this.prepareAndShowPage(AppState.INVITED);
+            break;
+          case SessionInviteState.NO_INVITES:
+            // TODO: What to do here?
+                break;
+        }
+      }
+    );
+
+    return pagePromise;
+  }
+
+}
+

--- a/src/providers/app-state/app-state.ts
+++ b/src/providers/app-state/app-state.ts
@@ -1,0 +1,17 @@
+/**
+ * Created by jett on 12/24/18.
+ */
+
+/**
+ * Formalizes the various states of the application for steering the
+ * page presentation and other logic.
+ */
+export enum AppState {
+
+  UNREGISTERED,     // This device needs to be registered
+  READY_TO_PLAY,    // We have accepted an invitation for an outing
+  INVITED,          // There is an outstanding invitation
+  NO_INVITES,       // No current invites or outings
+  EXCEPTION         // Exception has occurred such that we can't tell what state we should be in
+
+}

--- a/src/providers/resources/outing/outing.ts
+++ b/src/providers/resources/outing/outing.ts
@@ -1,5 +1,5 @@
-import {Course} from "../course/course";
-import {Team} from "../team/team";
+// import {Course} from "../course/course";
+// import {Team} from "../team/team";
 
 /**
  * Created by jett on 8/6/18.


### PR DESCRIPTION
…load

- Adds AppState service holding logic for steering which page to present.

Some cleanup of lint.

Drops the back-versioning of ws:3.3.2 (websockets).

First use of the async/await construct for making an asynchronous call
into a synchronous call; makes the code read easier when nesting the
asynch calls.

This commit is dependent on FEC-29.