### PR TITLE
FEC-8: Moves to cached Outing View from Session

### DIFF
--- a/src/components/pinned-map/pinned-map.ts
+++ b/src/components/pinned-map/pinned-map.ts
@@ -1,6 +1,5 @@
 import {Component, Input} from '@angular/core';
 import {LatLon} from "../lat-lon";
-import {Observable} from "rxjs/Observable";
 import * as L from "leaflet";
 
 /**
@@ -15,8 +14,7 @@ import * as L from "leaflet";
 })
 export class PinnedMapComponent {
 
-  @Input() pinObservable: Observable<LatLon>;
-  pin: LatLon = new LatLon();
+  @Input() pin: LatLon;
   map: any;
   zoomLevel = 14;
 
@@ -24,22 +22,6 @@ export class PinnedMapComponent {
   }
 
   ngOnInit(): void {
-    /* postpone showing the map until the position comes back from the server. */
-    this.pinObservable.subscribe(
-      (latLon) => {
-        this.pin.lat = latLon.lat;
-        this.pin.lon = latLon.lon;
-        this.pin.lng = latLon.lon;
-        this.pin.id = latLon.id;
-        this.showMap();
-      }
-    );
-  }
-
-  /**
-   * Build the map and open to the position defined by the 'pin'.
-   */
-  showMap(): void {
     this.map = L.map('pinned-map');
 
     let leafletPosition = [
@@ -56,7 +38,9 @@ export class PinnedMapComponent {
 
   /* Cleanup after ourselves. */
   ngOnDestroy(): void {
-    this.map.remove();
+    if (this.map) {
+      this.map.remove();
+    }
   }
 
 }

--- a/src/pages/outing/outing.html
+++ b/src/pages/outing/outing.html
@@ -39,7 +39,7 @@
     <a (click)="showTeam()">{{outing.teamName}}</a>
   </div>
 
-  <pinned-map class="map-content" [pinObservable]='pinObservable'></pinned-map>
+  <pinned-map class="map-content" [pin]='outing.startPin'></pinned-map>
 
   <begin-game></begin-game>
 

--- a/src/pages/outing/outing.ts
+++ b/src/pages/outing/outing.ts
@@ -1,10 +1,7 @@
 import { Component } from '@angular/core';
 import { IonicPage, NavController, NavParams } from 'ionic-angular';
-import {LatLon} from "../../components/lat-lon";
-import {Observable} from "rxjs/Observable";
-import {OutingService} from "../../../../front-end-common/index";
-import {OutingView} from "../../../../front-end-common/index";
-import {Subject} from "rxjs/Subject";
+import {OutingService} from "front-end-common";
+import {OutingView} from "front-end-common";
 import {Title} from "@angular/platform-browser";
 
 /**
@@ -19,8 +16,6 @@ import {Title} from "@angular/platform-browser";
 export class OutingPage {
 
   outing: OutingView = new OutingView();
-  pinSubject: Subject<LatLon> = new Subject<LatLon>();
-  pinObservable: Observable<LatLon> = this.pinSubject.asObservable();
 
   constructor(
     public navCtrl: NavController,
@@ -28,17 +23,9 @@ export class OutingPage {
     public titleService: Title,
     public outingService: OutingService,
   ) {
-    /* TODO: FEC-8
-     * Consider that an outing only changes as the invitation is accepted and can be held within
-     * the Outing Service.
-     */
-    // TODO: CA-376 pickup Outing from session as part of accepting the Invite.
-    let outingId: number = 1;
-
-    outingService.get(outingId).subscribe(
+    outingService.getSessionOuting().subscribe(
+      /* Generally, the Outing has been cached. */
       (response) => {
-        console.log("Got Outing View; sending Pin to subject");
-        this.pinSubject.next(response.startPin);
         this.outing = response;
       }
     );

--- a/src/providers/app-state/app-state.service.ts
+++ b/src/providers/app-state/app-state.service.ts
@@ -1,7 +1,7 @@
 import {App, NavController} from "ionic-angular";
 import {AppState} from "./app-state";
 import {Injectable} from "@angular/core";
-import {RegistrationPage, InviteService, SessionInviteState} from "../../../../front-end-common/index";
+import {RegistrationPage, InviteService, OutingService, SessionInviteState} from "../../../../front-end-common/index";
 import {HomePage} from "../../pages/home/home";
 import {InvitePage} from "../../pages/invite/invite";
 import {ProfileService, ConfirmationListener, ConfirmationState} from "../../../../front-end-common/src/providers/profile/profile.service";
@@ -24,6 +24,7 @@ export class AppStateService implements ConfirmationListener {
     public app: App,
     public inviteService: InviteService,
     public profileService: ProfileService,
+    private outingService: OutingService,
   ) {
     /** Add ourselves to the list of profile listeners. */
     profileService.listeners.push(this);
@@ -63,6 +64,10 @@ export class AppStateService implements ConfirmationListener {
 
       case AppState.READY_TO_PLAY:
         console.log("Headed to the Home Page");
+        this.outingService.getSessionOuting().subscribe(
+          /* Not used here; we're pre-populating the cache. */
+          () => {}
+        );
         pageReadyPromise = this.nav.setRoot(HomePage);
         break;
 


### PR DESCRIPTION
- Triggers retrieval of Outing once we know we've got an accepted invite
(although INITIAL is probably OK too).
- Removes Observable for the pin going into pinned-map component along
with pushing the subject when the Outing Page receives the Outing.