### PR TITLE
PLAY-44 Place an Edge on the map

### DIFF
--- a/src/components/rolling-map/rolling-map.html
+++ b/src/components/rolling-map/rolling-map.html
@@ -1,5 +1,6 @@
 <!-- Generated template for the RollingMapComponent component -->
-<div>
+<div class="map-container" id="rolling-map">
+
   <div *ngIf="isGuide()">
     <ion-fab left bottom>
       <button ion-fab mini (tap)="signalArrival()">
@@ -7,4 +8,5 @@
       </button>
     </ion-fab>
   </div>
+
 </div>

--- a/src/components/rolling-map/rolling-map.scss
+++ b/src/components/rolling-map/rolling-map.scss
@@ -1,3 +1,6 @@
 rolling-map {
 
 }
+.map-container {
+  height: 100%;
+}

--- a/src/components/rolling-map/rolling-map.ts
+++ b/src/components/rolling-map/rolling-map.ts
@@ -1,7 +1,9 @@
 import {Component, Input} from "@angular/core";
 import {GuideEventServiceProvider} from "../../providers/resources/guide-events/guide-event.service.provider";
 import {GuideEventService} from "../../providers/resources/guide-events/guide-event.service";
-import {OutingView} from "../../../../front-end-common/index";
+import {EdgeService, OutingView} from "../../../../front-end-common/index";
+
+import * as L from "leaflet";
 
 @Component({
   selector: 'rolling-map',
@@ -15,11 +17,45 @@ export class RollingMapComponent {
 
   @Input() memberId: Number;
   @Input() outing: OutingView;
+  map: any;
+  zoomLevel: number = 14;
+  edgeLayer: any;
 
   constructor(
-    private guideEventService: GuideEventService
+    private guideEventService: GuideEventService,
+    private edgeService: EdgeService,
   ) {
     console.log('Hello RollingMapComponent Component');
+  }
+
+  ngOnInit(): void {
+    this.map = L.map('rolling-map');
+
+    /* Temporary just to get the map in the ball-park of the track I've pulled in. */
+    let leafletPosition = [
+      33.76,
+      -84.38
+    ];
+
+    this.map.setView(leafletPosition, this.zoomLevel);
+    L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png').addTo(this.map);
+    /* Providing a layer upon which we pile on the stuff we show the user should be easier this way. */
+    this.edgeLayer = L.geoJSON().addTo(this.map);
+
+    /* When changes come in, we throw them into the layer. */
+    this.edgeService.getEdgeGeoJson(238).subscribe(
+      (edge) => {
+        this.edgeLayer.addData(edge);
+      }
+    );
+
+  }
+
+  /* Cleanup after ourselves. */
+  ngOnDestroy(): void {
+    if (this.map) {
+      this.map.remove();
+    }
   }
 
   public isGuide(): boolean {

--- a/src/pages/rolling/rolling.html
+++ b/src/pages/rolling/rolling.html
@@ -16,7 +16,7 @@
 </ion-header>
 
 
-<ion-content padding>
+<ion-content>
   <rolling-map [memberId]="7"
                [outing]="outing">
   </rolling-map>


### PR DESCRIPTION
- Adds EdgeService to provide the Rolling Map with a track to place.
- Amends the HTML template to place the map.
- Changes the CSS to provide full height to the container.
- Removes padding from the page so map can fill entire screen.

This hardcodes an initial position for the map instead of centering on content. Once the patterns for bringing across content settle out, this will change to centering on that content.

This does introduce an "edgeLayer", that we'll want to get more sophisticated about. The Subscribe model works well to push those changes. Will be interesting to see how it plays out in the field.