### PR TITLE
Exploring how we respond to Game State to present Paths on the map

### DIFF
--- a/src/components/begin-game/begin-game.ts
+++ b/src/components/begin-game/begin-game.ts
@@ -1,5 +1,7 @@
 import { Component } from '@angular/core';
 import {NavController} from "ionic-angular";
+import {ServerEventsService} from "../../providers/server-events/server-events.service";
+import {OutingService} from "../../../../front-end-common/index";
 
 /**
  * Generated class for the BeginGameComponent component.
@@ -14,12 +16,23 @@ import {NavController} from "ionic-angular";
 export class BeginGameComponent {
 
   constructor(
-    public navCtrl: NavController
+    public navCtrl: NavController,
+    private outingService: OutingService,
+    private serverEventsService: ServerEventsService,
   ) {
   }
 
   public beginGame() {
     console.log('Beginning Game');
+
+    /* Request the session's outing and use the response to setup Game State subscriptions against the outing. */
+    this.outingService.getSessionOuting(). subscribe(
+      (outingView) => {
+        this.serverEventsService.initializeSubscriptions(outingView.id);
+      }
+    );
+
+    /* Kick us over to the Rolling Page's Map view. */
     this.navCtrl.setRoot("RollingPage");
   }
 

--- a/src/components/rolling-map/rolling-map.ts
+++ b/src/components/rolling-map/rolling-map.ts
@@ -4,6 +4,7 @@ import {GuideEventService} from "../../providers/resources/guide-events/guide-ev
 import {PathService, OutingView} from "../../../../front-end-common/index";
 
 import * as L from "leaflet";
+import {GameState} from "../../providers/game-state/game-state";
 
 @Component({
   selector: 'rolling-map',
@@ -17,16 +18,33 @@ export class RollingMapComponent {
 
   @Input() memberId: Number;
   @Input() outing: OutingView;
+  @Input() gameState: GameState;
   map: any;
   zoomLevel: number = 14;
   edgeLayer: any;
 
+  dummyCourse = {
+    pathIds: []
+  }
+
   constructor(
     private guideEventService: GuideEventService,
-    // private edgeService: EdgeService,
     private pathService: PathService,
   ) {
     console.log('Hello RollingMapComponent Component');
+    // this.dummyCourse.pathIds.push(12);
+    // this.dummyCourse.pathIds.push(7);
+    // this.dummyCourse.pathIds.push(5);
+    // this.dummyCourse.pathIds.push(8);
+
+    this.dummyCourse.pathIds.push(6);
+    this.dummyCourse.pathIds.push(4);
+    this.dummyCourse.pathIds.push(3);
+    this.dummyCourse.pathIds.push(13);
+    this.dummyCourse.pathIds.push(9);
+    this.dummyCourse.pathIds.push(10);
+    this.dummyCourse.pathIds.push(2);
+
   }
 
   ngOnInit(): void {
@@ -44,11 +62,47 @@ export class RollingMapComponent {
     this.edgeLayer = L.geoJSON().addTo(this.map);
 
     /* When changes come in, we throw them into the layer. */
-    this.pathService.getPathGeoJson(13).subscribe(
-      (path) => {
-        this.edgeLayer.addData(path);
-      }
-    );
+    if (this.gameState) {
+      this.pathService.getPathGeoJson(this.dummyCourse.pathIds[this.gameState.pathIndex]).subscribe(
+        (path) => {
+          this.edgeLayer.addData(path);
+        }
+      );
+    }
+
+  }
+
+  ngOnChanges(changes) {
+    console.log("rolling-map component: ngOnChanges()");
+    if (changes.outing) {
+      console.log("rolling-map component: Outing has changed");
+      console.log("previous: " + changes.outing.previousValue);
+      console.log("current: " + changes.outing.currentValue);
+    }
+    if (changes.memberId) {
+      console.log("rolling-map component: Member ID has changed");
+      console.log("previous: " + changes.memberId.previousValue);
+      console.log("current: " + changes.memberId.currentValue);
+    }
+    if (changes.gameState) {
+      console.log("rolling-map component: Game State has changed");
+      console.log("previous: " + changes.gameState.previousValue);
+      console.log("current: " + changes.gameState.currentValue);
+    }
+    if (!changes.gameState) return;
+
+
+    /* When changes come in, we throw them into the layer. */
+    if (this.gameState) {
+      console.log("State change to path index " + this.gameState.pathIndex);
+      this.pathService.getPathGeoJson(this.dummyCourse.pathIds[this.gameState.pathIndex]).subscribe(
+        (path) => {
+          this.edgeLayer.addData(path);
+        }
+      );
+    } else {
+      console.log('No Game State yet');
+    }
 
   }
 

--- a/src/pages/puzzle/puzzle.ts
+++ b/src/pages/puzzle/puzzle.ts
@@ -36,6 +36,7 @@ export class PuzzlePage {
   }
 
   ionViewDidEnter() {
+    console.log("PuzzlePage.ionViewDidEnter");
     this.titleService.setTitle("Puzzle");
   }
 

--- a/src/pages/rolling/rolling.html
+++ b/src/pages/rolling/rolling.html
@@ -17,7 +17,9 @@
 
 
 <ion-content>
-  <rolling-map [memberId]="7"
-               [outing]="outing">
+  <rolling-map
+    [memberId]="7"
+    [outing]="outing"
+    [gameState]="gameState">
   </rolling-map>
 </ion-content>

--- a/src/pages/rolling/rolling.ts
+++ b/src/pages/rolling/rolling.ts
@@ -1,8 +1,8 @@
 import {Component} from "@angular/core";
-import {IonicPage, NavController, NavParams} from "ionic-angular";
-import {OutingService} from "../../../../front-end-common/index";
-import {OutingView} from "../../../../front-end-common/index";
-import {ServerEventsService} from "../../providers/server-events/server-events.service";
+import {GameState} from "../../providers/game-state/game-state";
+import {GameStateService} from "../../providers/game-state/game-state.service";
+import {IonicPage} from "ionic-angular";
+import {OutingService, OutingView} from "../../../../front-end-common/index";
 import {Title} from "@angular/platform-browser";
 
 /**
@@ -10,7 +10,6 @@ import {Title} from "@angular/platform-browser";
  *
  * This serves as the "root" of a game tree of pages, whose state changes are driven
  * by the subscription to the Game State (via the ServerEventsService).
- *
  */
 
 @IonicPage()
@@ -23,14 +22,14 @@ import {Title} from "@angular/platform-browser";
 })
 export class RollingPage {
   outing: OutingView;
+  gameState: GameState;
 
   constructor(
-    private serverEvents: ServerEventsService,
-    public navCtrl: NavController,
-    public navParams: NavParams,
+    private gameStateService: GameStateService,
     public outingService: OutingService,
     public titleService: Title,
   ) {
+    console.log("Hello RollingPage");
   }
 
   ionViewDidLoad() {
@@ -39,19 +38,23 @@ export class RollingPage {
     // TODO: CA-376 how to establish Outing?
     const outingId = 1;
 
-    this.serverEvents.initializeSubscriptions(outingId);
-
-    this.outingService.get(
-      outingId
-    ).subscribe(
+    this.outingService.getSessionOuting().subscribe(
       (outing) => {
         this.outing = outing;
+      }
+    );
+
+    this.gameStateService.getGameStateObservable().subscribe(
+      (gameState) => {
+        console.log("Rolling Page: Updating Game State");
+        this.gameState = Object.assign({}, gameState);
       }
     );
 
   }
 
   ionViewDidEnter() {
+    console.log("RollingPage.ionViewDidEnter");
     this.titleService.setTitle("Rolling");
   }
 

--- a/src/providers/game-state/game-state.service.ts
+++ b/src/providers/game-state/game-state.service.ts
@@ -1,11 +1,15 @@
 import {Injectable} from "@angular/core";
 import {App, NavController} from "ionic-angular";
+import {GameState} from "./game-state";
+import {Observable, Subject} from "rxjs";
 
 /** Drives updating the Team Members synchronously between
  * Sleuthing (upon Arrival) and Rolling (upon Departure).
  */
 @Injectable()
 export class GameStateService {
+  private gameStateSubject: Subject<GameState> = new Subject();
+  private gameStateObservable: Observable<GameState> = this.gameStateSubject.asObservable();
 
   constructor(
     public app: App
@@ -20,19 +24,32 @@ export class GameStateService {
       case "Team Assembled":
       case "Arrival":
         /* Case where we send out a Puzzle to be solved. */
-        (<NavController>this.app.getRootNavById('n4')).push("PuzzlePage");
+        (<NavController>this.app.getRootNavById('n4')).setRoot("PuzzlePage");
         break;
 
       case "Departure":
         /* Case where we update the map to show the next path and we begin riding again. */
-        (<NavController>this.app.getRootNavById('n4')).popToRoot();
-        // Do I need to respond to the promise?
+        (
+          <NavController>this.app.getRootNavById('n4')
+        ).setRoot(
+          "RollingPage"
+        ).then(
+          () => {
+            console.log("After Page Navigation completes: GameState is " + JSON.stringify(event.gameState));
+            this.gameStateSubject.next(event.gameState);
+          }
+        );
         break;
 
       default:
         console.log("Unrecognized Event: " + event.event);
         break;
     }
+
+  }
+
+  getGameStateObservable() {
+    return this.gameStateObservable;
   }
 
 }

--- a/src/providers/game-state/game-state.ts
+++ b/src/providers/game-state/game-state.ts
@@ -1,0 +1,6 @@
+export class GameState {
+  teamAssembled: boolean;
+  rolling: boolean;
+  nextLocation: string;
+  pathIndex: number;
+}

--- a/src/providers/server-events/server-events.service.ts
+++ b/src/providers/server-events/server-events.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import {Injectable} from '@angular/core';
 import {EventSourcePolyfill} from "ng-event-source";
 import {GameStateService} from "../game-state/game-state.service";
 import {TokenService} from "../../../../front-end-common/index";
@@ -20,36 +20,42 @@ export class ServerEventsService {
   }
 
   /**
-   * Begins listening for Game State events on the channel for the given Outing ID.
+   * Handles life-cycle for Game State events on the channel for the given Outing ID.
+   *
+   * All Messages are forwarded to the GameStateService for triggering UI changes.
    * @param outingId
    */
-  public initializeSubscriptions(outingId: number) {
+  public initializeSubscriptions(outingId: number): void {
+
     if (!this.eventSource) {
       let bearerToken = this.tokenService.getBearerToken();
 
       console.log("Opening Event Source");
-      this.eventSource = new EventSourcePolyfill(gameStateUrl + "/" + outingId, {
-        headers: {
-          Authorization: `Bearer ${bearerToken}`
+      this.eventSource = new EventSourcePolyfill(
+        gameStateUrl + "/" + outingId,
+        {
+          headers: {
+            Authorization: `Bearer ${bearerToken}`
+          }
         }
-      });
+      );
 
       this.eventSource.onmessage = (
         (messageEvent) => {
-          console.log("SSE Message: " + messageEvent.data);
+          console.log("SSE Message: " + JSON.stringify(messageEvent.data));
           this.gameStateService.updateFromEvent(messageEvent.data);
         }
       );
 
       this.eventSource.onopen = (
         (openEvent) => {
-          console.log("SSE Open: " + openEvent)
+          console.log("SSE Open: " + JSON.stringify(openEvent))
         }
       );
 
       this.eventSource.onerror = (
         (error) => {
-          console.log("SSE Error: " + error)
+          console.log("SSE Error: " + JSON.stringify(error))
         }
       );
 


### PR DESCRIPTION
- Adds lots of logging to provide life-cycle visibility.
- Begins subscriptions to GameState events at the time user decides to begin the game.
- GameStateService responsible for providing Subject that subscribers can listen to for these changes. Rolling Page is current subscriber.
- Passes Game State into rolling-map component via
  - Subscription in Service,
  - @Input in component,
  - ngOnChanges() within component controller

Learning that our navigation choices are limited. When "Setting Root", a new instance of the page is created. We only want a single instance of our pages. This commit is limited in what it can do for that reason because each transition to the Rolling/Map page adds a new copy to the subscriber list.