### PR TITLE
explore-course-from-service

### DIFF
--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -13,7 +13,7 @@ import {BadgesPage} from "../pages/badges/badges";
 import {HomePage} from "../pages/home/home";
 import {OutingPage} from "../pages/outing/outing";
 import {RollingPage} from "../pages/rolling/rolling";
-import {TeamPage} from "../pages/team/team";
+import {TeamPage} from "../pages/team/team-page";
 
 @Component({
   templateUrl: 'app.html'

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -16,12 +16,14 @@ import {InvitePage} from "../pages/invite/invite";
 import {InvitePageModule} from "../pages/invite/invite.module";
 import {OutingPage} from "../pages/outing/outing";
 import {OutingPageModule} from "../pages/outing/outing.module";
+import {PuzzlePage} from "../pages/puzzle/puzzle-page";
+import {PuzzlePageModule} from "../pages/puzzle/puzzle-page.module";
 import {RollingPage} from "../pages/rolling/rolling";
 import {RollingPageModule} from "../pages/rolling/rolling.module";
 import {ServerEventsService} from "../providers/server-events/server-events.service";
 import {SummaryComponentsModule} from "../components/components.module";
-import {TeamPage} from "../pages/team/team";
-import {TeamPageModule} from "../pages/team/team.module";
+import {TeamPage} from "../pages/team/team-page";
+import {TeamPageModule} from "../pages/team/team-page.module";
 
 @NgModule({
   declarations: [
@@ -34,6 +36,7 @@ import {TeamPageModule} from "../pages/team/team.module";
     IonicModule.forRoot(MyApp),
     ComponentsModule.forRoot(),
     InvitePageModule,
+    PuzzlePageModule,
     RollingPageModule,
     OutingPageModule,
     SummaryComponentsModule,
@@ -46,6 +49,7 @@ import {TeamPageModule} from "../pages/team/team.module";
     HomePage,
     InvitePage,
     OutingPage,
+    PuzzlePage,
     RollingPage,
     TeamPage,
   ],

--- a/src/components/begin-game/begin-game.ts
+++ b/src/components/begin-game/begin-game.ts
@@ -1,7 +1,7 @@
-import { Component } from '@angular/core';
+import {Component} from '@angular/core';
 import {NavController} from "ionic-angular";
 import {ServerEventsService} from "../../providers/server-events/server-events.service";
-import {OutingService} from "../../../../front-end-common/index";
+import {OutingService} from "front-end-common";
 
 /**
  * Generated class for the BeginGameComponent component.

--- a/src/components/profile-summary/profile-summary.ts
+++ b/src/components/profile-summary/profile-summary.ts
@@ -1,5 +1,5 @@
-import { Component } from '@angular/core';
-import {ProfileService} from "../../../../front-end-common/src/providers/profile/profile.service";
+import {Component} from '@angular/core';
+import {ProfileService} from "front-end-common";
 
 /**
  * Generated class for the ProfileSummaryComponent component.

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -1,5 +1,15 @@
 import {Component} from "@angular/core";
-import {AuthService} from "front-end-common";
+import {
+  AuthService,
+  Course,
+  CourseService,
+  LocationService,
+  OutingService,
+  PathService,
+  PuzzleService,
+  OutingView,
+  TeamService,
+} from "front-end-common";
 import {Title} from "@angular/platform-browser";
 
 @Component({
@@ -7,15 +17,69 @@ import {Title} from "@angular/platform-browser";
   templateUrl: 'home.html'
 })
 export class HomePage {
+  private outing: OutingView;
+  private course: Course;
 
   constructor(
+    /* Used on the HTML page: */
     public auth: AuthService,
+
+    private outingService: OutingService,
+    private courseService: CourseService,
+    private pathService: PathService,
+    private locationService: LocationService,
+    private puzzleService: PuzzleService,
+    private teamService: TeamService,
     public titleService: Title,
   ) {
+  }
+
+  ionViewDidLoad() {
+    this.loadOutingData();
+  }
+
+  /**
+   * In sequence, brings in the entire set of data for a course.
+   */
+  private loadOutingData() {
+    this.outingService.getSessionOuting().subscribe(
+      (response) => {
+        this.outing = <OutingView> response;
+        /* Kick off loads of everything needing the Outing ID: */
+        this.loadCourseData();
+        this.teamService.loadTeam(this.outing.teamId);
+      }
+    );
+  }
+
+  private loadCourseData() {
+    this.courseService.getSessionCourse().subscribe(
+      (response) => {
+        this.course = response;
+        this.loadLocationData();
+      }
+    );
+
+  }
+
+  private loadLocationData() {
+    this.locationService.loadSessionLocations().subscribe(
+      (response) => {
+        this.loadPuzzleData();
+      }
+    );
+
+  }
+
+  private loadPuzzleData() {
+    this.puzzleService.loadSessionPuzzles().subscribe(
+      (response) => {
+        console.log("Completed loading Course, Location, and Puzzles");
+      }
+    );
   }
 
   ionViewDidEnter() {
     this.titleService.setTitle("Home");
   }
-
 }

--- a/src/pages/outing/outing.ts
+++ b/src/pages/outing/outing.ts
@@ -1,7 +1,6 @@
-import { Component } from '@angular/core';
-import { IonicPage, NavController, NavParams } from 'ionic-angular';
-import {OutingService} from "front-end-common";
-import {OutingView} from "front-end-common";
+import {Component} from '@angular/core';
+import {IonicPage, NavController} from 'ionic-angular';
+import {OutingService, OutingView} from "front-end-common";
 import {Title} from "@angular/platform-browser";
 
 /**
@@ -19,13 +18,13 @@ export class OutingPage {
 
   constructor(
     public navCtrl: NavController,
-    public navParams: NavParams,
     public titleService: Title,
     public outingService: OutingService,
   ) {
     outingService.getSessionOuting().subscribe(
       /* Generally, the Outing has been cached. */
       (response) => {
+        console.log("Receiving Outing from Service");
         this.outing = response;
       }
     );

--- a/src/pages/puzzle/puzzle-page.module.ts
+++ b/src/pages/puzzle/puzzle-page.module.ts
@@ -1,6 +1,6 @@
 import { NgModule } from '@angular/core';
 import { IonicPageModule } from 'ionic-angular';
-import { PuzzlePage } from './puzzle';
+import { PuzzlePage } from './puzzle-page';
 
 @NgModule({
   declarations: [

--- a/src/pages/puzzle/puzzle-page.ts
+++ b/src/pages/puzzle/puzzle-page.ts
@@ -1,7 +1,8 @@
-import { Component } from '@angular/core';
-import { IonicPage, NavController, NavParams } from 'ionic-angular';
+import {Component} from '@angular/core';
+import {IonicPage} from 'ionic-angular';
 import {GuideEventServiceProvider} from "../../providers/resources/guide-events/guide-event.service.provider";
 import {GuideEventService} from "../../providers/resources/guide-events/guide-event.service";
+import {LocationService, Puzzle, PuzzleService} from "front-end-common";
 import {Title} from "@angular/platform-browser";
 
 /**
@@ -22,10 +23,13 @@ import {Title} from "@angular/platform-browser";
 })
 export class PuzzlePage {
 
+  private puzzles: Puzzle[];
+  puzzle: Puzzle = new Puzzle();
+
   constructor(
     private guideEventService: GuideEventService,
-    public navCtrl: NavController,
-    public navParams: NavParams,
+    private puzzleService: PuzzleService,
+    private locationService: LocationService,
     public titleService: Title,
   ) {
 
@@ -33,6 +37,12 @@ export class PuzzlePage {
 
   ionViewDidLoad() {
     console.log('ionViewDidLoad PuzzlePage');
+
+    let locationId = this.locationService.getCurrentLocationId();
+    this.puzzles = this.puzzleService.getPuzzlesPerLocationId(locationId);
+    if (this.puzzles && this.puzzles.length > 0) {
+      this.puzzle = this.puzzles[0];
+    }
   }
 
   ionViewDidEnter() {

--- a/src/pages/puzzle/puzzle.html
+++ b/src/pages/puzzle/puzzle.html
@@ -14,7 +14,61 @@
 
 
 <ion-content padding>
+  <ion-grid>
 
+    <ion-row>
+      <ion-col col-2>
+        <ion-label>Name</ion-label>
+      </ion-col>
+      <ion-col col-10>
+        <ion-input class="value-field"
+                   [(ngModel)]="puzzle.name">
+        </ion-input>
+      </ion-col>
+    </ion-row>
+
+    <ion-row>
+      <ion-col col-3>
+        <ion-label>Question</ion-label>
+      </ion-col>
+      <ion-col col-9>
+        <ion-textarea class="value-field"
+                      [(ngModel)]="puzzle.question">
+        </ion-textarea>
+      </ion-col>
+    </ion-row>
+
+    <!-- Answer Section -->
+    <ion-row *ngFor="let answer of puzzle.answers">
+      <ion-col col-1 (click)="selectCorrectAnswer(answer.key)">
+        <ion-label>{{answer.key}}:</ion-label>
+      </ion-col>
+      <ion-col col-11>
+        <ion-textarea class="value-field"
+                      [ngClass]="{
+                      'correct-answer': answer.key == puzzle.correctAnswer,
+                      'incorrect-answer': answer.key !== puzzle.correctAnswer
+                    }"
+                      [(ngModel)]="answer.answer">
+        </ion-textarea>
+      </ion-col>
+    </ion-row>
+
+    <!-- Correct Answer -->
+    <ion-row>
+      <ion-col col-6>
+        <ion-label>
+          Correct Answer
+        </ion-label>
+      </ion-col>
+      <ion-col col-6>
+        <ion-label class="left-label">
+          {{puzzle.correctAnswer}}
+        </ion-label>
+      </ion-col>
+    </ion-row>
+
+  </ion-grid>
   <div *ngIf="isGuide()">
     <ion-fab left bottom>
       <button ion-fab mini (tap)="signalPuzzleSolved()">

--- a/src/pages/rolling/rolling.ts
+++ b/src/pages/rolling/rolling.ts
@@ -2,8 +2,9 @@ import {Component} from "@angular/core";
 import {GameState} from "../../providers/game-state/game-state";
 import {GameStateService} from "../../providers/game-state/game-state.service";
 import {IonicPage} from "ionic-angular";
-import {OutingService, OutingView} from "../../../../front-end-common/index";
+import {OutingService, OutingView} from "front-end-common";
 import {Title} from "@angular/platform-browser";
+import {Subscription} from "rxjs";
 
 /**
  * Presents the map for the game while "Rolling".
@@ -16,13 +17,11 @@ import {Title} from "@angular/platform-browser";
 @Component({
   selector: 'page-rolling',
   templateUrl: 'rolling.html',
-  providers: [
-    OutingService,
-  ],
 })
 export class RollingPage {
   outing: OutingView;
   gameState: GameState;
+  gameStateSubscription: Subscription;
 
   constructor(
     private gameStateService: GameStateService,
@@ -35,19 +34,16 @@ export class RollingPage {
   ionViewDidLoad() {
     console.log('ionViewDidLoad RollingPage');
 
-    // TODO: CA-376 how to establish Outing?
-    const outingId = 1;
-
     this.outingService.getSessionOuting().subscribe(
       (outing) => {
         this.outing = outing;
       }
     );
 
-    this.gameStateService.getGameStateObservable().subscribe(
+    this.gameStateSubscription = this.gameStateService.getGameStateObservable().subscribe(
       (gameState) => {
         console.log("Rolling Page: Updating Game State");
-        this.gameState = Object.assign({}, gameState);
+        this.gameState = gameState;
       }
     );
 
@@ -56,6 +52,10 @@ export class RollingPage {
   ionViewDidEnter() {
     console.log("RollingPage.ionViewDidEnter");
     this.titleService.setTitle("Rolling");
+  }
+
+  ngOnDestroy() {
+    this.gameStateSubscription.unsubscribe();
   }
 
 }

--- a/src/pages/team/team-page.module.ts
+++ b/src/pages/team/team-page.module.ts
@@ -1,6 +1,6 @@
-import { NgModule } from '@angular/core';
-import { IonicPageModule } from 'ionic-angular';
-import { TeamPage } from './team';
+import {NgModule} from '@angular/core';
+import {IonicPageModule} from 'ionic-angular';
+import {TeamPage} from './team-page';
 
 @NgModule({
   declarations: [

--- a/src/pages/team/team-page.ts
+++ b/src/pages/team/team-page.ts
@@ -1,8 +1,9 @@
 import {Component} from "@angular/core";
-import {IonicPage, NavController, NavParams} from "ionic-angular";
+import {IonicPage, NavController} from "ionic-angular";
 import {GuideEventService} from "../../providers/resources/guide-events/guide-event.service";
 import {GuideEventServiceProvider} from "../../providers/resources/guide-events/guide-event.service.provider";
 import {Title} from "@angular/platform-browser";
+import {Team, TeamService} from "front-end-common";
 
 /**
  * Generated class for the TeamPage page.
@@ -22,16 +23,23 @@ import {Title} from "@angular/platform-browser";
 })
 export class TeamPage {
 
+  public team: Team = {
+    id: 0,
+    name: 'Team',
+    members: []
+  };
+
   constructor(
     private guideEventService: GuideEventService,
+    private teamService: TeamService,
     public navCtrl: NavController,
-    public navParams: NavParams,
     public titleService: Title,
   ) {
   }
 
   ionViewDidLoad() {
     console.log('ionViewDidLoad TeamPage');
+    this.team = this.teamService.getTeam();
   }
 
   ionViewDidEnter() {

--- a/src/pages/team/team.html
+++ b/src/pages/team/team.html
@@ -10,13 +10,17 @@
     <button ion-button menuToggle>
       <ion-icon name="menu"></ion-icon>
     </button>
-    <ion-title>Team</ion-title>
+    <ion-title>{{team.name}}</ion-title>
   </ion-navbar>
 
 </ion-header>
 
 
 <ion-content padding>
+  <li *ngFor="let member of team.members">
+    {{member.displayName}}
+  </li>
+
   <div *ngIf="isGuide()">
     <ion-fab left bottom>
       <button ion-fab mini (tap)="signalTeamAssembled()">

--- a/src/providers/app-state/app-state.service.ts
+++ b/src/providers/app-state/app-state.service.ts
@@ -1,10 +1,10 @@
 import {App, NavController} from "ionic-angular";
 import {AppState} from "./app-state";
 import {Injectable} from "@angular/core";
-import {RegistrationPage, InviteService, OutingService, SessionInviteState} from "../../../../front-end-common/index";
+import {RegistrationPage, InviteService, OutingService, SessionInviteState} from "front-end-common";
 import {HomePage} from "../../pages/home/home";
 import {InvitePage} from "../../pages/invite/invite";
-import {ProfileService, ConfirmationListener, ConfirmationState} from "../../../../front-end-common/src/providers/profile/profile.service";
+import {ProfileService, ConfirmationListener, ConfirmationState} from "front-end-common";
 
 /**
  * Provides the logic for arranging Application State changes:

--- a/src/providers/resources/team/team.ts
+++ b/src/providers/resources/team/team.ts
@@ -1,8 +1,0 @@
-/**
- * Created by jett on 8/6/18.
- */
-
-export class Team {
-  id: number;
-  name: string;
-}

--- a/src/providers/server-events/server-events.service.ts
+++ b/src/providers/server-events/server-events.service.ts
@@ -1,7 +1,7 @@
 import {Injectable} from '@angular/core';
 import {EventSourcePolyfill} from "ng-event-source";
 import {GameStateService} from "../game-state/game-state.service";
-import {TokenService} from "../../../../front-end-common/index";
+import {TokenService} from "front-end-common";
 
 const gameStateUrl: string = 'http://sse.clueride.com/game-state-broadcast';
 


### PR DESCRIPTION
- Most significant: HomePage responsible for loading the Course data in a controlled manner.
- Distinguishing between Team and TeamPage and Puzzle and PuzzlePage. (Team definition moved into FEC).
- Clean-up of front-end-common import.

Pages (other than Home) are getting out of the business of being responsible for constructing the static course structure. The pages were dynamically created and destroyed, so their life-cycle was inappropriate for generating the Service structure.