### PR TITLE
PLAY-56 Paths aren't being presented correctly

### DIFF
--- a/src/components/badge-summary/badge-summary.html
+++ b/src/components/badge-summary/badge-summary.html
@@ -6,7 +6,7 @@
 
 <!--
 
-TODO: Turn this into a component supported by Guide Event Service.
+TODO: Turn this into a component supported by Guide Event Service. Maybe PLAY-50?
 
   <div id="guide-capability">
     <ng-template [ngIf]="isGuide()" [ngIfElse]="notGuide">


### PR DESCRIPTION
- Caches the paths -- which weren't being cached.
- Changes getPath service to return Paths synchronously from cache.
- Changes rolling-map to use stream to index through the Paths and
Locations that are being added to the map.