### PR TITLE
remove-ngx-restangular

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,6 @@
         "ionicons": "3.0.0",
         "leaflet": "^1.2.0",
         "ng-event-source": "^1.0.9",
-        "ngx-restangular": "^2.0.2",
         "sw-toolbox": "3.6.0",
         "zone.js": "0.8.18"
     },


### PR DESCRIPTION
- Removes the dependency from Player.

This appears to be bringing in the @types/lodash that has problems
transpiling on iOS.