### PR TITLE
PLAY-67 Profile image comes up blank (null)

### DIFF
--- a/src/components/profile-summary/profile-summary.html
+++ b/src/components/profile-summary/profile-summary.html
@@ -1,11 +1,13 @@
-<!-- Generated template for the ProfileSummaryComponent component -->
-<div class="section-heading">Registered as</div>
-<div class="profile-summary">
-  <div class="user-image">
-    <img [src] = "profile.getUserImageUrl()">
-  </div>
-  <div class="name">
-    {{profile.getDisplayName()}}<br>
-    {{profile.getPrincipal()}}
+<div *ngIf="profile">
+  <div class="section-heading">Registered as</div>
+  <div class="profile-summary">
+    <div class="user-image"
+         *ngIf="profile.imageUrl">
+      <img [src]="profile.imageUrl">
+    </div>
+    <div class="name">
+      {{profile.displayName}}<br>
+      {{profile.emailAddress}}
+    </div>
   </div>
 </div>

--- a/src/components/profile-summary/profile-summary.ts
+++ b/src/components/profile-summary/profile-summary.ts
@@ -1,5 +1,5 @@
-import {Component} from '@angular/core';
-import {ProfileService} from "front-end-common";
+import {Component, Input} from '@angular/core';
+import {Member} from "../../../../front-end-common/src/providers/profile/member";
 
 /**
  * Generated class for the ProfileSummaryComponent component.
@@ -13,9 +13,11 @@ import {ProfileService} from "front-end-common";
 })
 export class ProfileSummaryComponent {
 
+  @Input() profile: Member;
+
   constructor(
-    public profile: ProfileService
   ) {
+
   }
 
 }

--- a/src/pages/home/home.html
+++ b/src/pages/home/home.html
@@ -14,7 +14,7 @@
 
   <outing-summary></outing-summary>
 
-  <profile-summary></profile-summary>
+  <profile-summary [profile]="member"></profile-summary>
 
   <badge-summary></badge-summary>
 

--- a/src/pages/home/home.ts
+++ b/src/pages/home/home.ts
@@ -2,12 +2,15 @@ import {Component} from "@angular/core";
 import {AuthService, ProfileService, PlatformStateService,} from "front-end-common";
 import {Title} from "@angular/platform-browser";
 import {LoadStateService} from "../../providers/load-state/load-state.service";
+import {Member} from "../../../../front-end-common/src/providers/profile/member";
 
 @Component({
   selector: 'page-home',
   templateUrl: 'home.html'
 })
 export class HomePage {
+
+  member: Member;
 
   constructor(
     /* Used on the HTML page: */
@@ -20,7 +23,12 @@ export class HomePage {
   }
 
   ionViewDidLoad() {
-    this.profileService.loadMemberProfile();
+    this.profileService.loadMemberProfile()
+      .subscribe(
+        (member) => {
+          this.member = member;
+        }
+      );
     this.loadStateService.loadOutingData();
   }
 


### PR DESCRIPTION
- Puts the Member instance in the parent (Home) page.
- Passes the Member instance to the Profile component as @Input.
- Adds `ngIf` guards within the template to gracefully handle the absence
of both the profile and the image.