### PR TITLE
PLAY-71 Team Page: move the members to ion-chips

### DIFF
--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -8,6 +8,7 @@ import {InviteListComponent} from './invite-list/invite-list';
 import {OutingSummaryComponent} from "./outing-summary/outing-summary";
 import {PinnedMapComponent} from './pinned-map/pinned-map';
 import {ProfileSummaryComponent} from "./profile-summary/profile-summary";
+import {TeamMemberChipComponent} from './team-member-chip/team-member-chip';
 
 @NgModule({
 	declarations: [
@@ -17,6 +18,7 @@ import {ProfileSummaryComponent} from "./profile-summary/profile-summary";
     InviteListComponent,
     PinnedMapComponent,
     ProfileSummaryComponent,
+    TeamMemberChipComponent,
   ],
 	imports: [
     IonicPageModule,
@@ -29,6 +31,7 @@ import {ProfileSummaryComponent} from "./profile-summary/profile-summary";
     InviteListComponent,
     PinnedMapComponent,
     ProfileSummaryComponent,
+    TeamMemberChipComponent,
   ]
 })
 

--- a/src/components/team-member-chip/team-member-chip.html
+++ b/src/components/team-member-chip/team-member-chip.html
@@ -1,0 +1,13 @@
+<ion-chip>
+
+  <ion-avatar>
+    <img [src]="member.imageUrl">
+  </ion-avatar>
+
+  <div class="member-display-name">
+    {{member.displayName}}
+  </div>
+
+  <div class="badge-count"></div>
+
+</ion-chip>

--- a/src/components/team-member-chip/team-member-chip.scss
+++ b/src/components/team-member-chip/team-member-chip.scss
@@ -1,0 +1,7 @@
+team-member-chip {
+
+}
+
+.member-display-name {
+  padding: 0 10px;
+}

--- a/src/components/team-member-chip/team-member-chip.ts
+++ b/src/components/team-member-chip/team-member-chip.ts
@@ -1,0 +1,21 @@
+import {Component, Input} from '@angular/core';
+import {Member} from "../../../../front-end-common/src/providers/profile/member";
+
+/**
+ * Generated class for the TeamMemberChipComponent component.
+ *
+ * See https://angular.io/api/core/Component for more info on Angular
+ * Components.
+ */
+@Component({
+  selector: 'team-member-chip',
+  templateUrl: 'team-member-chip.html'
+})
+export class TeamMemberChipComponent {
+
+  @Input() member: Member;
+
+  constructor() {
+  }
+
+}

--- a/src/pages/team/team-page.module.ts
+++ b/src/pages/team/team-page.module.ts
@@ -1,6 +1,7 @@
 import {NgModule} from '@angular/core';
 import {IonicPageModule} from 'ionic-angular';
 import {TeamPage} from './team-page';
+import {SummaryComponentsModule} from "../../components/components.module";
 
 @NgModule({
   declarations: [
@@ -8,6 +9,7 @@ import {TeamPage} from './team-page';
   ],
   imports: [
     IonicPageModule.forChild(TeamPage),
+    SummaryComponentsModule,
   ],
 })
 export class TeamPageModule {}

--- a/src/pages/team/team.html
+++ b/src/pages/team/team.html
@@ -17,9 +17,19 @@
 
 
 <ion-content padding>
-  <li *ngFor="let member of team.members">
-    {{member.displayName}}
-  </li>
+  <ion-card>
+
+    <ion-card-header>Team Members for this Outing</ion-card-header>
+    <ion-card-content>
+
+      <ion-list *ngFor="let member of team.members">
+        <ion-item>
+          <team-member-chip [member]="member"></team-member-chip>
+        </ion-item>
+      </ion-list>
+
+    </ion-card-content>
+  </ion-card>
 
   <div *ngIf="isGuide()">
     <ion-fab left bottom>


### PR DESCRIPTION
- Adds `team-member-chip` to be included within ion-list.
- Turns team page's simple for loop into ion-list with ion-items.

CSS needed a bit of adjustment to get the text to sit well within the chip.