### PR TITLE
PLAY-77 Pinned Map and Rolling Map are inadvertantly sharing CSS

### DIFF
--- a/src/components/pinned-map/pinned-map.scss
+++ b/src/components/pinned-map/pinned-map.scss
@@ -1,6 +1,6 @@
 pinned-map {
 }
 
-.map-container {
-  max-height: 50%;
+#pinned-map {
+  height: 50%;
 }

--- a/src/pages/rolling/rolling.scss
+++ b/src/pages/rolling/rolling.scss
@@ -1,6 +1,7 @@
 page-rolling {
 
 }
-.map-container {
+
+#rolling-map {
   height: 100%;
 }


### PR DESCRIPTION
- Places styling on the ID rather than the class.