### PR TITLE
Android launch mode as singleTask

### DIFF
--- a/config.xml
+++ b/config.xml
@@ -14,6 +14,7 @@
     <hook src="scripts/before_prepare_increment_build_number.js" type="before_prepare" />
     <preference name="ScrollEnabled" value="false" />
     <preference name="android-minSdkVersion" value="16" />
+    <preference name="AndroidLaunchMode" value="singleTask" />
     <preference name="BackupWebStorage" value="none" />
     <preference name="SplashMaintainAspectRatio" value="true" />
     <preference name="FadeSplashScreenDuration" value="300" />


### PR DESCRIPTION
This appears to allow Android to stay connected to "inspect" sessions
when passing control over to Auth0 websites. iOS was already doing this.