### PR TITLE
PLAY-90 Badge Event Popup / Overlay

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -769,7 +769,7 @@
     "async-limiter": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/async-limiter/-/async-limiter-1.0.0.tgz",
-      "integrity": "sha512-jp/uFnooOiO+L211eZOoSyzpOITMXx1rBITauYykG3BRYPu8h0UcxsPNB04RR5vo4Tyz3+ay17tR6JVf9qzYWg==",
+      "integrity": "sha1-ePrtjD0HSrgfIrTphdeehzj3IPg=",
       "dev": true
     },
     "asynckit": {
@@ -6457,7 +6457,7 @@
     "ng-event-source": {
       "version": "1.0.14",
       "resolved": "https://registry.npmjs.org/ng-event-source/-/ng-event-source-1.0.14.tgz",
-      "integrity": "sha1-xVA12sBKxJQeSo63p8Jt7S2NlOU="
+      "integrity": "sha512-RtgmjtTDSQG1yDcsVzT1Yafv6E2PlF64/f2TouN+/DyQuWIFYRg+qOvRJMB08Nqy76CJB30Mvsw6InHrmrGTvg=="
     },
     "nice-try": {
       "version": "1.0.5",
@@ -9606,7 +9606,7 @@
     "ultron": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
-      "integrity": "sha512-UIEXBNeYmKptWH6z8ZnqTeS8fV74zG0/eRU9VGkpzz+LIJNs8W/zM/L+7ctCkRrgbNnnR0xxw4bKOr0cW0N0Og==",
+      "integrity": "sha1-n+FTahCmZKZSZqHjzPhf02MCvJw=",
       "dev": true
     },
     "underscore": {

--- a/package.json
+++ b/package.json
@@ -50,7 +50,7 @@
     "ionicons": "3.0.0",
     "leaflet": "^1.2.0",
     "leaflet.awesome-markers": "^2.0.5",
-    "ng-event-source": "^1.0.9",
+    "ng-event-source": "^1.0.14",
     "sw-toolbox": "3.6.0",
     "zone.js": "0.8.18"
   },

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -36,7 +36,7 @@ export class MyApp {
     public statusBar: StatusBar,
     public splashScreen: SplashScreen,
     public appStateService: AppStateService,
-    public platformService: PlatformStateService,
+    public platformStateService: PlatformStateService,
     private regStateService: RegStateService,
   ) {
   }
@@ -47,7 +47,7 @@ export class MyApp {
 
       // Okay, so the platform is ready and our plugins are available.
       // Here you can do any higher level native things you might need.
-      if (this.platformService.isNativeMode()) {
+      if (this.platformStateService.isNativeMode()) {
         /* Since this is a cordova native statusbar, only set style if not within a browser (local). */
         this.statusBar.styleDefault();
       }
@@ -82,7 +82,7 @@ export class MyApp {
     /* Handle Registration -- generally, a one-time occurrence, but there are re-tries. */
     regStateObservable.pipe(
       filter(regState => regState.state === RegStateKey.REGISTRATION_REQUIRED)
-    ).subscribe(regState => {
+    ).subscribe(() => {
       console.log("We need to show the Registration Page");
       this.nav.setRoot(RegistrationPage)
         .then()
@@ -92,7 +92,7 @@ export class MyApp {
     /* Handle Profile Confirmation -- generally, a one-time occurrence, but there are re-tries. */
     regStateObservable.pipe(
       filter(regState => regState.state === RegStateKey.CONFIRMATION_REQUIRED)
-    ).subscribe( regState => {
+    ).subscribe(() => {
         console.log("We need to show the Confirmation Page");
         this.nav.setRoot(ConfirmPage)
           .then()

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -15,5 +15,7 @@
 
 </ion-menu>
 
+<popup-monitor></popup-monitor>
+
 <!-- Disable swipe-to-go-back because it's poor UX to combine STGB with side menus -->
 <ion-nav [root]="rootPage" #content swipeBackEnabled="false"></ion-nav>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -24,6 +24,7 @@ import {InvitePageModule} from "../pages/invite/invite.module";
 import {LocationPage} from "../pages/location/location";
 import {LocationPageModule} from "../pages/location/location.module";
 import {MarkerService} from '../providers/marker-service/marker-service';
+import {NewBadgePageModule} from "../pages/new-badge/new-badge.module";
 import {OutingPage} from "../pages/outing/outing";
 import {OutingPageModule} from "../pages/outing/outing.module";
 import {PrivacyPage} from "../pages/privacy/privacy";
@@ -59,6 +60,7 @@ import {MyApp} from "./app.component";
     InvitePageModule,
     LocationPageModule,
     MemberChipComponentModule,
+    NewBadgePageModule,
     PrivacyPageModule,
     PuzzlePageModule,
     RollingPageModule,

--- a/src/components/badge-event/badge-event.ts
+++ b/src/components/badge-event/badge-event.ts
@@ -1,0 +1,9 @@
+import {BadgeFeatures} from "front-end-common";
+
+/**
+ * What is received from SSE when a Badge is awarded.
+ */
+export class BadgeEvent {
+  userId: number;
+  badgeFeatures: BadgeFeatures;
+}

--- a/src/components/components.module.ts
+++ b/src/components/components.module.ts
@@ -11,6 +11,8 @@ import {PinnedMapComponent} from './pinned-map/pinned-map';
 import {ProfileSummaryComponent} from "./profile-summary/profile-summary";
 import { ProgressChipComponent } from './progress-chip/progress-chip';
 import { RegisteredAsComponent } from './registered-as/registered-as';
+import { NewBadgePopupComponent } from './new-badge-popup/new-badge-popup';
+import { PopupMonitorComponent } from './popup-monitor/popup-monitor';
 
 @NgModule({
 	declarations: [
@@ -22,6 +24,8 @@ import { RegisteredAsComponent } from './registered-as/registered-as';
     ProfileSummaryComponent,
     ProgressChipComponent,
     RegisteredAsComponent,
+    NewBadgePopupComponent,
+    PopupMonitorComponent,
   ],
 	imports: [
     BadgesPerLevelModule,
@@ -37,6 +41,8 @@ import { RegisteredAsComponent } from './registered-as/registered-as';
     ProfileSummaryComponent,
     ProgressChipComponent,
     RegisteredAsComponent,
+    NewBadgePopupComponent,
+    PopupMonitorComponent,
   ]
 })
 

--- a/src/components/new-badge-popup/new-badge-popup.html
+++ b/src/components/new-badge-popup/new-badge-popup.html
@@ -1,0 +1,3 @@
+<!-- Intentionally empty because it happens to show right before the home page. -->
+<div>
+</div>

--- a/src/components/new-badge-popup/new-badge-popup.scss
+++ b/src/components/new-badge-popup/new-badge-popup.scss
@@ -1,0 +1,3 @@
+new-badge-popup {
+
+}

--- a/src/components/new-badge-popup/new-badge-popup.ts
+++ b/src/components/new-badge-popup/new-badge-popup.ts
@@ -1,0 +1,17 @@
+import {Component} from '@angular/core';
+
+/**
+ * Shell for the Popup Modal.
+ */
+@Component({
+  selector: 'new-badge-popup',
+  templateUrl: 'new-badge-popup.html'
+})
+export class NewBadgePopupComponent {
+
+  constructor(
+  ) {
+    console.log('Hello NewBadgePopupComponent Component');
+  }
+
+}

--- a/src/components/popup-monitor/popup-monitor.html
+++ b/src/components/popup-monitor/popup-monitor.html
@@ -1,0 +1,2 @@
+<new-badge-popup>
+</new-badge-popup>

--- a/src/components/popup-monitor/popup-monitor.scss
+++ b/src/components/popup-monitor/popup-monitor.scss
@@ -1,0 +1,3 @@
+popup-monitor {
+
+}

--- a/src/components/popup-monitor/popup-monitor.ts
+++ b/src/components/popup-monitor/popup-monitor.ts
@@ -1,0 +1,59 @@
+import {Component} from '@angular/core';
+import {ModalController} from "ionic-angular";
+import {ServerEventsService} from "../../providers/server-events/server-events.service";
+import {BadgeEvent} from "../badge-event/badge-event";
+import {NewBadgePage} from "../../pages/new-badge/new-badge";
+import {LoadStateService} from "../../providers/load-state/load-state.service";
+
+/**
+ * Component that listens for the ready flag to know when it can start monitoring
+ * for Badge Events; once the event occurs, this is responsible for opening (and closing)
+ * the modal that presents the new Badge.
+ */
+@Component({
+  selector: 'popup-monitor',
+  templateUrl: 'popup-monitor.html'
+})
+export class PopupMonitorComponent {
+
+  text: string;
+
+  constructor(
+    private modalCtrl: ModalController,
+    private sseService: ServerEventsService,
+    private loadStateService: LoadStateService,
+  ) {
+    console.log('Hello PopupMonitorComponent Component');
+    this.text = 'Hello World';
+    this.loadStateService.getLoadStateObservable().subscribe(
+      (readyFlag) => {
+        if (readyFlag) {
+          this.beginMonitoring();
+        }
+      }
+    );
+  }
+
+  public beginMonitoring() {
+    console.log('Popup Monitor - begin monitoring');
+    this.sseService.getBadgeEventObservable().subscribe(
+      (badge: BadgeEvent) => {
+        console.info("Modal received a badge event with ID", badge.badgeFeatures.id, "for user", badge.userId);
+        this.presentNewBadge(badge);
+      }
+    );
+  }
+
+  /**
+   * Given a BadgeEvent, present it within a modal dialog.
+   * @param badge: BadgeEvent of the awarded badge.
+   */
+  private presentNewBadge(badge: BadgeEvent) {
+    let myModal = this.modalCtrl.create(
+      NewBadgePage,
+      badge
+    );
+    myModal.present();
+  }
+
+}

--- a/src/pages/new-badge/new-badge.html
+++ b/src/pages/new-badge/new-badge.html
@@ -1,0 +1,22 @@
+<ion-header>
+
+  <ion-navbar>
+    <ion-title>You've Earned a New Badge</ion-title>
+  </ion-navbar>
+
+</ion-header>
+
+
+<ion-content padding>
+  <!-- Badge ID: {{badge.id}} -->
+  <div class="badge-image">
+    <a [attr.href]="badge.criteriaUrl">
+      <img src="{{badge.imageUrl}}"/>
+    </a>
+  </div>
+
+  <div class="bottom-buttons">
+    <button ion-button color="" (click)="dismiss()">Close</button>
+  </div>
+
+</ion-content>

--- a/src/pages/new-badge/new-badge.module.ts
+++ b/src/pages/new-badge/new-badge.module.ts
@@ -1,0 +1,13 @@
+import { NgModule } from '@angular/core';
+import { IonicPageModule } from 'ionic-angular';
+import { NewBadgePage } from './new-badge';
+
+@NgModule({
+  declarations: [
+    NewBadgePage,
+  ],
+  imports: [
+    IonicPageModule.forChild(NewBadgePage),
+  ],
+})
+export class NewBadgePageModule {}

--- a/src/pages/new-badge/new-badge.scss
+++ b/src/pages/new-badge/new-badge.scss
@@ -1,0 +1,3 @@
+page-new-badge {
+
+}

--- a/src/pages/new-badge/new-badge.ts
+++ b/src/pages/new-badge/new-badge.ts
@@ -1,0 +1,40 @@
+import { Component } from '@angular/core';
+import {
+  IonicPage,
+  NavController,
+  NavParams,
+  ViewController
+} from 'ionic-angular';
+import {BadgeFeatures} from "front-end-common";
+
+/**
+ * This is the page displayed when a New Badge is awarded.
+ *
+ * It is intended to be contained within a Modal Dialog.
+ */
+@IonicPage()
+@Component({
+  selector: 'page-new-badge',
+  templateUrl: 'new-badge.html',
+})
+export class NewBadgePage {
+
+  readonly badge: BadgeFeatures;
+
+  constructor(
+    public navCtrl: NavController,
+    public navParams: NavParams,
+    public viewCtrl: ViewController,
+  ) {
+    this.badge = navParams.get("badgeFeatures");
+  }
+
+  ionViewDidLoad() {
+    console.log('ionViewDidLoad NewBadgePage');
+  }
+
+  dismiss() {
+    this.viewCtrl.dismiss();
+  }
+
+}

--- a/src/pages/puzzle/puzzle-page.ts
+++ b/src/pages/puzzle/puzzle-page.ts
@@ -37,10 +37,11 @@ export class PuzzlePage {
   }
 
   ionViewDidEnter() {
-    console.log("PuzzlePage.ionViewDidEnter");
+    let puzzleId = this.navParams.get('id');
+    console.log("PuzzlePage.ionViewDidEnter; puzzleId = ", puzzleId);
     this.titleService.setTitle("Puzzle");
     this.puzzle = this.puzzleService.getPuzzle(
-      this.navParams.get('id')
+      puzzleId
     );
   }
 

--- a/src/providers/load-state/load-state.service.ts
+++ b/src/providers/load-state/load-state.service.ts
@@ -55,6 +55,10 @@ export class LoadStateService {
     return this.allCachedUp;
   }
 
+  public getLoadStateObservable(): Observable<boolean> {
+    return this.loadStateObservable;
+  }
+
   /**
    * In sequence, brings in the entire set of data for a course.
    */
@@ -125,7 +129,7 @@ export class LoadStateService {
         this.allCachedUp = true;
 
         /* Turns on SSE against our session's Outing ID. */
-        // TODO: When does this turn off? Application life-cycle?
+        // TODO: PLAY-22 When does this turn off? Application life-cycle?
         this.serverEventsService.initializeSubscriptions(
           this.outing.id
         );


### PR DESCRIPTION
- Adds the response to a Badge Event while working toward the consolidation
of the event channel under the `server-events.service`.
- Adds the Popup and page for displaying a new badge -- a rough page to
prove out the concepts.
- Fills out the Popup page
- Arranges the Badge Event to allow checking that User Session matches
the user Id of the awarded badge.